### PR TITLE
implement inactive activity indicator on progress bar

### DIFF
--- a/packages/rrweb-player/src/Controller.svelte
+++ b/packages/rrweb-player/src/Controller.svelte
@@ -54,7 +54,19 @@
     percentage = `${100 * percent}%`;
     dispatch('ui-update-progress', { payload: percent });
   }
+  type CustomEvent = {
+    name: string;
+    background: string;
+    position: string;
+  };
 
+  /**
+   * Calculate the tag position (percent) to be displayed on the progress bar.
+   * @param startTime - The start time of the session.
+   * @param endTime - The end time of the session.
+   * @param tagTime - The time of the tag.
+   * @returns The position of the tag. unit: percentage
+   */
   function position(startTime: number, endTime: number, tagTime: number) {
     const sessionDuration = endTime - startTime;
     const eventDuration = endTime - tagTime;
@@ -62,11 +74,6 @@
     return eventPosition.toFixed(2);
   }
 
-  type CustomEvent = {
-    name: string;
-    background: string;
-    position: string;
-  };
   let customEvents: CustomEvent[];
   $: customEvents = (() => {
     const { context } = replayer.service.state;
@@ -101,28 +108,34 @@
     width: string;
   }[];
   $: inactivePeriods = (() => {
-    const { context } = replayer.service.state;
-    const totalEvents = context.events.length;
-    const start = context.events[0].timestamp;
-    const end = context.events[totalEvents - 1].timestamp;
-    const periods = getInactivePeriods(context.events);
-    const getWidth = (
-      startTime: number,
-      endTime: number,
-      tagStart: number,
-      tagEnd: number,
-    ) => {
-      const sessionDuration = endTime - startTime;
-      const eventDuration = tagEnd - tagStart;
-      const width = (eventDuration / sessionDuration) * 100;
-      return width.toFixed(2);
-    };
-    return periods.map((period) => ({
-      name: 'inactive',
-      background: 'rgb(212 212 212)',
-      position: `${position(start, end, period[0])}%`,
-      width: `${getWidth(start, end, period[0], period[1])}%`,
-    }));
+    try {
+      const { context } = replayer.service.state;
+      const totalEvents = context.events.length;
+      const start = context.events[0].timestamp;
+      const end = context.events[totalEvents - 1].timestamp;
+      const periods = getInactivePeriods(context.events);
+      // calculate the indicator width.
+      const getWidth = (
+        startTime: number,
+        endTime: number,
+        tagStart: number,
+        tagEnd: number,
+      ) => {
+        const sessionDuration = endTime - startTime;
+        const eventDuration = tagEnd - tagStart;
+        const width = (eventDuration / sessionDuration) * 100;
+        return width.toFixed(2);
+      };
+      return periods.map((period) => ({
+        name: 'inactive period',
+        background: 'rgb(212 212 212)',
+        position: `${position(start, end, period[0])}%`,
+        width: `${getWidth(start, end, period[0], period[1])}%`,
+      }));
+    } catch (e) {
+      // For safety concern, if there is any error, the main function won't be affected.
+      return [];
+    }
   })();
 
   const loopTimer = () => {
@@ -204,11 +217,11 @@
   };
 
   export const playRange = (
-     timeOffset: number,
-     endTimeOffset: number,
-     startLooping: boolean = false,
-     afterHook: undefined | (() => void) = undefined,
-   ) => {
+    timeOffset: number,
+    endTimeOffset: number,
+    startLooping: boolean = false,
+    afterHook: undefined | (() => void) = undefined,
+  ) => {
     if (startLooping) {
       loop = {
         start: timeOffset,
@@ -223,7 +236,6 @@
     replayer.play(timeOffset);
   };
 
-
   const handleProgressClick = (event: MouseEvent) => {
     if (speedState === 'skipping') {
       return;
@@ -237,7 +249,7 @@
       percent = 1;
     }
     const timeOffset = meta.totalTime * percent;
-    finished = false
+    finished = false;
     goto(timeOffset);
   };
 
@@ -260,18 +272,18 @@
   export const triggerUpdateMeta = () => {
     return Promise.resolve().then(() => {
       meta = replayer.getMetaData();
-    })
-  }
+    });
+  };
 
   onMount(() => {
     playerState = replayer.service.state.value;
-    speedState = replayer.speedService.state.value ;
+    speedState = replayer.speedService.state.value;
     replayer.on(
       'state-change',
       (states: { player?: PlayerMachineState; speed?: SpeedMachineState }) => {
         const { player, speed } = states;
         if (player?.value && playerState !== player.value) {
-          playerState = player.value ;
+          playerState = player.value;
           switch (playerState) {
             case 'playing':
               loopTimer();
@@ -284,7 +296,7 @@
           }
         }
         if (speed?.value && speedState !== speed.value) {
-          speedState = speed.value ;
+          speedState = speed.value;
         }
       },
     );
@@ -414,11 +426,13 @@
         class="rr-progress"
         class:disabled={speedState === 'skipping'}
         bind:this={progress}
-        on:click={handleProgressClick}>
+        on:click={handleProgressClick}
+      >
         <div
           class="rr-progress__step"
           bind:this={step}
-          style="width: {percentage}" />
+          style="width: {percentage}"
+        />
         {#each inactivePeriods as period}
           <div
             title={period.name}
@@ -431,7 +445,8 @@
             title={event.name}
             style="width: 10px;height: 5px;position: absolute;top:
             2px;transform: translate(-50%, -50%);background: {event.background};left:
-            {event.position};" />
+            {event.position};"
+          />
         {/each}
 
         <div class="rr-progress__handler" style="left: {percentage}" />
@@ -448,7 +463,8 @@
             xmlns="http://www.w3.org/2000/svg"
             xmlns:xlink="http://www.w3.org/1999/xlink"
             width="16"
-            height="16">
+            height="16"
+          >
             <path
               d="M682.65984 128q53.00224 0 90.50112 37.49888t37.49888 90.50112l0
               512q0 53.00224-37.49888 90.50112t-90.50112
@@ -463,7 +479,8 @@
               12.4928-30.16704l0-512q0-17.67424-12.4928-30.16704t-30.16704-12.4928zM682.65984
               213.34016q-17.67424 0-30.16704 12.4928t-12.4928 30.16704l0 512q0
               17.67424 12.4928 30.16704t30.16704 12.4928 30.16704-12.4928
-              12.4928-30.16704l0-512q0-17.67424-12.4928-30.16704t-30.16704-12.4928z" />
+              12.4928-30.16704l0-512q0-17.67424-12.4928-30.16704t-30.16704-12.4928z"
+            />
           </svg>
         {:else}
           <svg
@@ -473,10 +490,12 @@
             xmlns="http://www.w3.org/2000/svg"
             xmlns:xlink="http://www.w3.org/1999/xlink"
             width="16"
-            height="16">
+            height="16"
+          >
             <path
               d="M170.65984 896l0-768 640 384zM644.66944
-              512l-388.66944-233.32864 0 466.65728z" />
+              512l-388.66944-233.32864 0 466.65728z"
+            />
           </svg>
         {/if}
       </button>
@@ -484,7 +503,8 @@
         <button
           class:active={s === speed && speedState !== 'skipping'}
           on:click={() => setSpeed(s)}
-          disabled={speedState === 'skipping'}>
+          disabled={speedState === 'skipping'}
+        >
           {s}x
         </button>
       {/each}
@@ -492,7 +512,8 @@
         id="skip"
         bind:checked={skipInactive}
         disabled={speedState === 'skipping'}
-        label="skip inactive" />
+        label="skip inactive"
+      />
       <button on:click={() => dispatch('fullscreen')}>
         <svg
           class="icon"
@@ -501,10 +522,10 @@
           xmlns="http://www.w3.org/2000/svg"
           xmlns:xlink="http://www.w3.org/1999/xlink"
           width="16"
-          height="16">
+          height="16"
+        >
           <defs>
             <style type="text/css">
-
             </style>
           </defs>
           <path
@@ -515,7 +536,8 @@
             48s-21.6 48-48 48l-224 0c-26.4 0-48-21.6-48-48l0-224c0-26.4 21.6-48
             48-48 26.4 0 48 21.6 48 48L164 792l253.6-253.6c18.4-18.4 48.8-18.4
             68 0 18.4 18.4 18.4 48.8 0 68L231.2 860z"
-            p-id="1286" />
+            p-id="1286"
+          />
         </svg>
       </button>
     </div>

--- a/packages/rrweb-player/src/Controller.svelte
+++ b/packages/rrweb-player/src/Controller.svelte
@@ -54,6 +54,14 @@
     percentage = `${100 * percent}%`;
     dispatch('ui-update-progress', { payload: percent });
   }
+
+  function position(startTime: number, endTime: number, tagTime: number) {
+    const sessionDuration = endTime - startTime;
+    const eventDuration = endTime - tagTime;
+    const eventPosition = 100 - (eventDuration / sessionDuration) * 100;
+    return eventPosition.toFixed(2);
+  }
+
   type CustomEvent = {
     name: string;
     background: string;
@@ -66,15 +74,6 @@
     const start = context.events[0].timestamp;
     const end = context.events[totalEvents - 1].timestamp;
     const customEvents: CustomEvent[] = [];
-
-    // calculate tag position.
-    const position = (startTime: number, endTime: number, tagTime: number) => {
-      const sessionDuration = endTime - startTime;
-      const eventDuration = endTime - tagTime;
-      const eventPosition = 100 - (eventDuration / sessionDuration) * 100;
-
-      return eventPosition.toFixed(2);
-    };
 
     // loop through all the events and find out custom event.
     context.events.forEach((event) => {
@@ -107,14 +106,6 @@
     const start = context.events[0].timestamp;
     const end = context.events[totalEvents - 1].timestamp;
     const periods = getInactivePeriods(context.events);
-    // calculate tag position.
-    const position = (startTime: number, endTime: number, tagTime: number) => {
-      const sessionDuration = endTime - startTime;
-      const eventDuration = endTime - tagTime;
-      const eventPosition = 100 - (eventDuration / sessionDuration) * 100;
-
-      return eventPosition.toFixed(2);
-    };
     const getWidth = (
       startTime: number,
       endTime: number,
@@ -130,7 +121,7 @@
       name: 'inactive',
       background: 'rgb(212 212 212)',
       position: `${position(start, end, period[0])}%`,
-      width: getWidth(start, end, period[0], period[1]),
+      width: `${getWidth(start, end, period[0], period[1])}%`,
     }));
   })();
 
@@ -428,10 +419,13 @@
           class="rr-progress__step"
           bind:this={step}
           style="width: {percentage}" />
-        <div
-          title="inactive period"
-          style="width: 5%;height: 4px;position: absolute;background: rgb(255 0 0);left: 5%"
-        />
+        {#each inactivePeriods as period}
+          <div
+            title={period.name}
+            style="width: {period.width};height: 4px;position: absolute;background: {period.background};left:
+            {period.position};"
+          />
+        {/each}
         {#each customEvents as event}
           <div
             title={event.name}

--- a/packages/rrweb-player/src/Controller.svelte
+++ b/packages/rrweb-player/src/Controller.svelte
@@ -389,6 +389,10 @@
           class="rr-progress__step"
           bind:this={step}
           style="width: {percentage}" />
+        <div
+          title="inactive period"
+          style="width: 5%;height: 4px;position: absolute;background: rgb(255 0 0);left: 5%"
+        />
         {#each customEvents as event}
           <div
             title={event.name}

--- a/packages/rrweb-player/src/Controller.svelte
+++ b/packages/rrweb-player/src/Controller.svelte
@@ -12,7 +12,7 @@
     createEventDispatcher,
     afterUpdate,
   } from 'svelte';
-  import { formatTime } from './utils';
+  import { formatTime, getInactivePeriods } from './utils';
   import Switch from './components/Switch.svelte';
 
   const dispatch = createEventDispatcher();
@@ -93,6 +93,31 @@
     });
 
     return customEvents;
+  })();
+
+  type InactivePeriod = {
+    name: string;
+    background: string;
+    position: string;
+  };
+  let inactivePeriods: InactivePeriod[];
+  $: inactivePeriods = (() => {
+    const { context } = replayer.service.state;
+    const totalEvents = context.events.length;
+    const start = context.events[0].timestamp;
+    const end = context.events[totalEvents - 1].timestamp;
+    const periods = getInactivePeriods(context.events);
+
+    // calculate tag position.
+    const position = (startTime: number, endTime: number, tagTime: number) => {
+      const sessionDuration = endTime - startTime;
+      const eventDuration = endTime - tagTime;
+      const eventPosition = 100 - (eventDuration / sessionDuration) * 100;
+
+      return eventPosition.toFixed(2);
+    };
+
+    return periods;
   })();
 
   const loopTimer = () => {

--- a/packages/rrweb-player/src/Controller.svelte
+++ b/packages/rrweb-player/src/Controller.svelte
@@ -95,19 +95,18 @@
     return customEvents;
   })();
 
-  type InactivePeriod = {
+  let inactivePeriods: {
     name: string;
     background: string;
     position: string;
-  };
-  let inactivePeriods: InactivePeriod[];
+    width: string;
+  }[];
   $: inactivePeriods = (() => {
     const { context } = replayer.service.state;
     const totalEvents = context.events.length;
     const start = context.events[0].timestamp;
     const end = context.events[totalEvents - 1].timestamp;
     const periods = getInactivePeriods(context.events);
-
     // calculate tag position.
     const position = (startTime: number, endTime: number, tagTime: number) => {
       const sessionDuration = endTime - startTime;
@@ -116,8 +115,23 @@
 
       return eventPosition.toFixed(2);
     };
-
-    return periods;
+    const getWidth = (
+      startTime: number,
+      endTime: number,
+      tagStart: number,
+      tagEnd: number,
+    ) => {
+      const sessionDuration = endTime - startTime;
+      const eventDuration = tagEnd - tagStart;
+      const width = (eventDuration / sessionDuration) * 100;
+      return width.toFixed(2);
+    };
+    return periods.map((period) => ({
+      name: 'inactive',
+      background: 'rgb(212 212 212)',
+      position: `${position(start, end, period[0])}%`,
+      width: getWidth(start, end, period[0], period[1]),
+    }));
   })();
 
   const loopTimer = () => {

--- a/packages/rrweb-player/src/utils.ts
+++ b/packages/rrweb-player/src/utils.ts
@@ -145,7 +145,12 @@ export function typeOf(
   return map[toString.call(obj)];
 }
 
-
+/**
+ * Forked from 'rrweb' replay/index.ts. The original function is not exported.
+ * Determine whether the event is a user interaction event
+ * @param event - event to be determined
+ * @returns true if the event is a user interaction event
+ */
 function isUserInteraction(event: eventWithTime): boolean {
   if (event.type !== EventType.IncrementalSnapshot) {
     return false;
@@ -156,13 +161,17 @@ function isUserInteraction(event: eventWithTime): boolean {
   );
 }
 
-
+// Forked from 'rrweb' replay/index.ts. A const threshold of inactive time.
 const SKIP_TIME_THRESHOLD = 10 * 1000;
 
-
+/**
+ * Get periods of time when no user interaction happened from a list of events.
+ * @param events - all events
+ * @returns periods of time consist with [start time, end time]
+ */
 export function getInactivePeriods(events: eventWithTime[]) {
-  const inactivePeriods = [];
-  let lastActiveTime = 0;
+  const inactivePeriods: [number, number][] = [];
+  let lastActiveTime = events[0].timestamp;
   for (const event of events) {
     if (!isUserInteraction(event)) continue;
     if (event.timestamp - lastActiveTime > SKIP_TIME_THRESHOLD) {


### PR DESCRIPTION
# feature request

The rrweb-player shows an indicator for snapshot events but it would also be nice, to have some sort of indication of the inactive portion of the recording during playback. Recorded events can span to several minutes and it might be useful to know before hand where the inactive part is so it can be skipped manually as-well

# tasks

- [x] a util function for detecting inactive periods
- [x] implementation of indicator UI on progress bar
- [x] get session events in Control.svelte and invoke util function to get invalid periods
- [x] calculate width of indicator according to the period length
- [x] combine calculation value with indicator UI
- [x]  manual test and bug fix
- [x] improve code quality
